### PR TITLE
use HasPropertyBlock/GetPropertyBlock in UdonBakeryAdapter

### DIFF
--- a/UdonBakeryAdapter.cs
+++ b/UdonBakeryAdapter.cs
@@ -32,6 +32,10 @@ public class UdonBakeryAdapter : UdonSharpBehaviour
         for (int i = 0; i < renderers.Length; i++)
         {
             MaterialPropertyBlock propertyBlock = new MaterialPropertyBlock();
+            if (renderers[i].HasPropertyBlock())
+            {
+                renderers[i].GetPropertyBlock(propertyBlock);
+            }
             propertyBlock.SetFloat("bakeryLightmapMode", bakeryLightmapMode[i]);
             propertyBlock.SetTexture("_RNM0", rnmTexture[i][0]);
             propertyBlock.SetTexture("_RNM1", rnmTexture[i][1]);


### PR DESCRIPTION
Other Udon scripts in the scene may use property blocks too, avoid overwriting their properties. BakeryVolumeReceiverUdon already does this.