### PR TITLE
Exclude EditorOnly-tagged gameobjects from listing

### DIFF
--- a/UdonBakeryAdapter.cs
+++ b/UdonBakeryAdapter.cs
@@ -102,8 +102,9 @@ public class UdonBakeryAdapterEditor : Editor
             Texture RNM1 = b.GetTexture("_RNM1");
             Texture RNM2 = b.GetTexture("_RNM2");
             int propertyLightmapMode = (int) b.GetFloat("bakeryLightmapMode");
+            bool tagFilter = !renderersEditor[i].gameObject.CompareTag("EditorOnly");
 
-            if (RNM0 && RNM1 && RNM2 && propertyLightmapMode != 0)
+            if (RNM0 && RNM1 && RNM2 && propertyLightmapMode != 0 && tagFilter)
             {
                 RNMTextures textures = new RNMTextures
                 {


### PR DESCRIPTION
EditorOnly-tagged GOs will not be contributed to the final build, but they will be referenced in the list. This leads to an NRE being thrown at runtime.