### PR TITLE
Added Skinned Mesh Renderers to be included in the properties.

### DIFF
--- a/UdonBakeryAdapter.cs
+++ b/UdonBakeryAdapter.cs
@@ -15,7 +15,7 @@ using VRC.Udon;
 public class UdonBakeryAdapter : UdonSharpBehaviour
 {
     public bool disableQuest = false;
-    public MeshRenderer[] renderers;
+    public Renderer[] renderers;
     public int[] bakeryLightmapMode;
     public Texture[][] rnmTexture;
     void Start()
@@ -89,8 +89,9 @@ public class UdonBakeryAdapterEditor : Editor
 
 
         MeshRenderer[] renderersEditor = UnityEngine.Object.FindObjectsOfType<MeshRenderer>();
+        SkinnedMeshRenderer[] skinnedRenderers = UnityEngine.Object.FindObjectsOfType<SkinnedMeshRenderer>();
 
-        List<MeshRenderer> renderersEditorClean = new List<MeshRenderer>();
+        List<Renderer> renderersEditorClean = new List<Renderer>();
 
         List<RNMTextures> rnmTexturesList = new List<RNMTextures>();
 
@@ -123,7 +124,32 @@ public class UdonBakeryAdapterEditor : Editor
 
         }
 
-        MeshRenderer[] r = renderersEditorClean.ToArray();
+        for (int i = 0; i < skinnedRenderers.Length; i++)
+        {
+            MaterialPropertyBlock b = new MaterialPropertyBlock();
+            skinnedRenderers[i].GetPropertyBlock(b);
+
+            Texture RNM0 = b.GetTexture("_RNM0");
+            Texture RNM1 = b.GetTexture("_RNM1");
+            Texture RNM2 = b.GetTexture("_RNM2");
+            int propertyLightmapMode = (int)b.GetFloat("bakeryLightmapMode");
+            bool tagFilter = !skinnedRenderers[i].gameObject.CompareTag("EditorOnly");
+
+            if (RNM0 && RNM1 && RNM2 && propertyLightmapMode != 0 && tagFilter)
+            {
+                RNMTextures textures = new RNMTextures
+                {
+                    RNM0 = RNM0,
+                    RNM1 = RNM1,
+                    RNM2 = RNM2
+                };
+                rnmTexturesList.Add(textures);
+                renderersEditorClean.Add(skinnedRenderers[i]);
+                bakeryLightmapModeEditor.Add(propertyLightmapMode);
+            }
+        }
+
+        Renderer[] r = renderersEditorClean.ToArray();
 
         Texture[][] bakeryTextures = new Texture[r.Length][];
 


### PR DESCRIPTION
It's probably not super common that Skinned Mesh Renderers are baked, however I ran into a use-case for it (giving a static object a very slight animation using blend shapes). These are the changes I made to the script to get it to work for me, if you want to include this it might be a good idea to either include in the readme a note on not using materials that use bakery modes on objects that are going to be moving significantly, or having a toggle option in the script itself to include skinned mesh renderers (or both).